### PR TITLE
Fix for INC 5312 - Image errors for Product with no image

### DIFF
--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image,
+        image: this.props.image ? this.props.image : "/placeholder.png",
         tagList: this.props.tagList,
       };
 

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Defaulted `item.image` to use `placeholder.bin` when there is no image url selected by the user at the time of creating new product

Attaching the screenshots with the fix
<img width="1022" alt="Screen Shot 2022-11-27 at 11 12 59 AM" src="https://user-images.githubusercontent.com/10002420/204155427-8db395f3-9ed5-454a-aef1-24c6e479d702.png">
<img width="1129" alt="Screen Shot 2022-11-27 at 11 13 10 AM" src="https://user-images.githubusercontent.com/10002420/204155428-2ac8c72e-be77-4cdf-8976-40a369bfad33.png">
<img width="1163" alt="Screen Shot 2022-11-27 at 11 13 23 AM" src="https://user-images.githubusercontent.com/10002420/204155429-6914192a-e1c7-4dd1-b35e-962da0c6d44b.png">
